### PR TITLE
New report format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,40 @@
-FROM alpine:3.20
-
-ENV PATH=/root/.local/bin:$PATH
+# syntax=docker/dockerfile:1-labs
+FROM alpine:3.20 AS build
+WORKDIR /app
 ENV PIPENV_VENV_IN_PROJECT=1
+
+RUN apk add --update \
+	python3-dev \
+	py3-pip \
+	curl \
+	gcc \
+	g++ \
+	libpq-dev \
+	musl-dev \
+	mariadb-dev \
+	unixodbc-dev
+
+COPY Pipfile Pipfile.lock /app/
+RUN pip3 install --break-system-packages pipenv && \
+	pipenv install --deploy
+
+
+FROM alpine:3.20
 WORKDIR /app
 
 RUN adduser -h /app -D -H -g "CSP Report Collector" csprc
-RUN apk add --update \
-  python3-dev \
-  py3-pip \
-  curl \
-  gcc \
-  g++ \
+RUN apk add --update --no-cache \
+  python3 \
   libpq-dev \
-  musl-dev \
   mariadb-dev \
-  unixodbc-dev \
-  postgresql \
-  && rm -rf /var/cache/apk/*
-RUN pip3 install --user pipenv
-ADD .flaskenv Pipfile Pipfile.lock src/* /app/
+  unixodbc-dev 
+COPY --from=build /app/ /app/
+COPY .flaskenv src/*.py /app/
+COPY --parents src/./templates/* /app/
+COPY --parents src/./static/* /app/
 RUN chown -Rc csprc:csprc /app
-RUN /root/.local/bin/pipenv install --deploy
 
 USER csprc
 EXPOSE 8000
 HEALTHCHECK CMD curl -fs localhost:8000/status
-CMD [".venv/bin/gunicorn", "--workers=2", "--bind=0.0.0.0:8000", "--name=csprc", "--access-logfile=-", "csp_report_collector:app"]
+CMD ["/app/.venv/bin/gunicorn", "--workers=2", "--bind=0.0.0.0:8000", "--name=csprc", "--access-logfile=-", "csp_report_collector:app"]

--- a/Pipfile
+++ b/Pipfile
@@ -1,27 +1,21 @@
 [[source]]
-name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
+name = "pypi"
 
 [packages]
-flask = "*"
 flask-sqlalchemy = "*"
+flask = "*"
 gunicorn = "*"
-mysqlclient = "*"
 psycopg = "*"
+mysqlclient = "*"
 pyodbc = "*"
 python-dotenv = "*"
-sqlalchemy = "*"
 
 [dev-packages]
-csp-report-collector = {file = ".", editable = true}
 black = "*"
 flake8 = "*"
-isort = "*"
-mongomock = "*"
 pytest = "*"
-pytest-cov = "*"
-pytest-dotenv = "*"
 semver = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0e2dd0f09649e232378bbaab7049150567e09bf7a6182b57f39524517976f00d"
+            "sha256": "ddedbd18d20b9a72103a4758570d5e9e64fa779b5e9dd7e0af64de5fa232881f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
+            "version": "==8.1.8"
         },
         "flask": {
             "hashes": [
@@ -48,6 +48,85 @@
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
+            "version": "==3.1.1"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e",
+                "sha256:03a088b9de532cbfe2ba2034b2b85e82df37874681e8c470d6fb2f8c04d7e4b7",
+                "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01",
+                "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1",
+                "sha256:09fc016b73c94e98e29af67ab7b9a879c307c6731a2c9da0db5a7d9b7edd1159",
+                "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563",
+                "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83",
+                "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9",
+                "sha256:1776fd7f989fc6b8d8c8cb8da1f6b82c5814957264d1f6cf818d475ec2bf6395",
+                "sha256:1d3755bcb2e02de341c55b4fca7a745a24a9e7212ac953f6b3a48d117d7257aa",
+                "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942",
+                "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1",
+                "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441",
+                "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22",
+                "sha256:346bed03fe47414091be4ad44786d1bd8bef0c3fcad6ed3dee074a032ab408a9",
+                "sha256:36b89d13c49216cadb828db8dfa6ce86bbbc476a82d3a6c397f0efae0525bdd0",
+                "sha256:37b9de5a96111fc15418819ab4c4432e4f3c2ede61e660b1e33971eba26ef9ba",
+                "sha256:396979749bd95f018296af156201d6211240e7a23090f50a8d5d18c370084dc3",
+                "sha256:3b2813dc3de8c1ee3f924e4d4227999285fd335d1bcc0d2be6dc3f1f6a318ec1",
+                "sha256:411f015496fec93c1c8cd4e5238da364e1da7a124bcb293f085bf2860c32c6f6",
+                "sha256:47da355d8687fd65240c364c90a31569a133b7b60de111c255ef5b606f2ae291",
+                "sha256:48ca08c771c268a768087b408658e216133aecd835c0ded47ce955381105ba39",
+                "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d",
+                "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467",
+                "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475",
+                "sha256:54558ea205654b50c438029505def3834e80f0869a70fb15b871c29b4575ddef",
+                "sha256:5e06afd14cbaf9e00899fae69b24a32f2196c19de08fcb9f4779dd4f004e5e7c",
+                "sha256:62ee94988d6b4722ce0028644418d93a52429e977d742ca2ccbe1c4f4a792511",
+                "sha256:63e4844797b975b9af3a3fb8f7866ff08775f5426925e1e0bbcfe7932059a12c",
+                "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822",
+                "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a",
+                "sha256:6ef9ea3f137e5711f0dbe5f9263e8c009b7069d8a1acea822bd5e9dae0ae49c8",
+                "sha256:7017b2be767b9d43cc31416aba48aab0d2309ee31b4dbf10a1d38fb7972bdf9d",
+                "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01",
+                "sha256:73aaad12ac0ff500f62cebed98d8789198ea0e6f233421059fa68a5aa7220145",
+                "sha256:77c386de38a60d1dfb8e55b8c1101d68c79dfdd25c7095d51fec2dd800892b80",
+                "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13",
+                "sha256:7939aa3ca7d2a1593596e7ac6d59391ff30281ef280d8632fa03d81f7c5f955e",
+                "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b",
+                "sha256:85f3ff71e2e60bd4b4932a043fbbe0f499e263c628390b285cb599154a3b03b1",
+                "sha256:8b8b36671f10ba80e159378df9c4f15c14098c4fd73a36b9ad715f057272fbef",
+                "sha256:93147c513fac16385d1036b7e5b102c7fbbdb163d556b791f0f11eada7ba65dc",
+                "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff",
+                "sha256:94b6150a85e1b33b40b1464a3f9988dcc5251d6ed06842abff82e42632fac120",
+                "sha256:94ebba31df2aa506d7b14866fed00ac141a867e63143fe5bca82a8e503b36437",
+                "sha256:95ffcf719966dd7c453f908e208e14cde192e09fde6c7186c8f1896ef778d8cd",
+                "sha256:98884ecf2ffb7d7fe6bd517e8eb99d31ff7855a840fa6d0d63cd07c037f6a981",
+                "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36",
+                "sha256:9e8f8c9cb53cdac7ba9793c276acd90168f416b9ce36799b9b885790f8ad6c0a",
+                "sha256:a0dfc6c143b519113354e780a50381508139b07d2177cb6ad6a08278ec655798",
+                "sha256:b2795058c23988728eec1f36a4e5e4ebad22f8320c85f3587b539b9ac84128d7",
+                "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761",
+                "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0",
+                "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e",
+                "sha256:b8da394b34370874b4572676f36acabac172602abf054cbc4ac910219f3340af",
+                "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa",
+                "sha256:c4aab7f6381f38a4b42f269057aee279ab0fc7bf2e929e3d4abfae97b682a12c",
+                "sha256:ca9d0ff5ad43e785350894d97e13633a66e2b50000e8a183a50a88d834752d42",
+                "sha256:d0028e725ee18175c6e422797c407874da24381ce0690d6b9396c204c7f7276e",
+                "sha256:d21e10da6ec19b457b82636209cbe2331ff4306b54d06fa04b7c138ba18c8a81",
+                "sha256:d5e975ca70269d66d17dd995dafc06f1b06e8cb1ec1e9ed54c1d1e4a7c4cf26e",
+                "sha256:da7a9bff22ce038e19bf62c4dd1ec8391062878710ded0a845bcf47cc0200617",
+                "sha256:db32b5348615a04b82240cc67983cb315309e88d444a288934ee6ceaebcad6cc",
+                "sha256:dcc62f31eae24de7f8dce72134c8651c58000d3b1868e01392baea7c32c247de",
+                "sha256:dfc59d69fc48664bc693842bd57acfdd490acafda1ab52c7836e3fc75c90a111",
+                "sha256:e347b3bfcf985a05e8c0b7d462ba6f15b1ee1c909e2dcad795e49e91b152c383",
+                "sha256:e4d333e558953648ca09d64f13e6d8f0523fa705f51cae3f03b5983489958c70",
+                "sha256:ed10eac5830befbdd0c32f83e8aa6288361597550ba669b04c48f0f9a2c843c6",
+                "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4",
+                "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011",
+                "sha256:f1d4aeb8891338e60d1ab6127af1fe45def5259def8094b9c7e34690c8858803",
+                "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79",
+                "sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f"
+            ],
+            "markers": "python_version >= '3.7'",
             "version": "==3.1.1"
         },
         "gunicorn": {
@@ -69,11 +148,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
-                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.4"
+            "version": "==3.1.6"
         },
         "markupsafe": {
             "hashes": [
@@ -144,18 +223,18 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:3da70a07753ba6be881f7d75e795e254f6a0c12795778034acc69769b0649d37",
-                "sha256:43c5b30be0675080b9c815f457d73397f0442173e7be83d089b126835e2617ae",
-                "sha256:794857bce4f9a1903a99786dd29ad7887f45a870b3d11585b8c51c4a753c4174",
-                "sha256:b0a5cddf1d3488b254605041070086cac743401d876a659a72d706a0d89c8ebb",
-                "sha256:c0b46d9b78b461dbb62482089ca8040fa916595b1b30f831ebbd1b0a82b43d53",
-                "sha256:e940b41d85dfd7b190fa47d52f525f878cfa203d4653bf6a35b271b3c3be125b",
-                "sha256:e94a92858203d97fd584bdb6d7ee8c56f2590db8d77fd44215c0dcf5e739bc37",
-                "sha256:f3efb849d6f7ef4b9788a0eda2e896b975e0ebf1d6bf3dcabea63fd698e5b0b5"
+                "sha256:199dab53a224357dd0cb4d78ca0e54018f9cee9bf9ec68d72db50e0a23569076",
+                "sha256:201a6faa301011dd07bca6b651fe5aaa546d7c9a5426835a06c3172e1056a3c5",
+                "sha256:24ae22b59416d5fcce7e99c9d37548350b4565baac82f95e149cac6ce4163845",
+                "sha256:2e3c11f7625029d7276ca506f8960a7fd3c5a0a0122c9e7404e6a8fe961b3d22",
+                "sha256:4b4c0200890837fc64014cc938ef2273252ab544c1b12a6c1d674c23943f3f2e",
+                "sha256:92af368ed9c9144737af569c86d3b6c74a012a6f6b792eb868384787b52bb585",
+                "sha256:977e35244fe6ef44124e9a1c2d1554728a7b76695598e4b92b37dc2130503069",
+                "sha256:a22d99d26baf4af68ebef430e3131bb5a9b722b79a9fcfac6d9bbf8a88800687"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.6"
+            "version": "==2.2.7"
         },
         "packaging": {
             "hashes": [
@@ -167,12 +246,12 @@
         },
         "psycopg": {
             "hashes": [
-                "sha256:644d3973fe26908c73d4be746074f6e5224b03c1101d302d9a53bf565ad64907",
-                "sha256:a5764f67c27bec8bfac85764d23c534af2c27b893550377e37ce59c12aac47a2"
+                "sha256:16fa094efa2698f260f2af74f3710f781e4a6f226efe9d1fd0c37f384639ed8a",
+                "sha256:f3ff5488525890abb0566c429146add66b329e20d6d4835662b920cbbf90ac58"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.2.3"
+            "version": "==3.2.6"
         },
         "pyodbc": {
             "hashes": [
@@ -229,67 +308,66 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:03e08af7a5f9386a43919eda9de33ffda16b44eb11f3b313e6822243770e9763",
-                "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436",
-                "sha256:07b441f7d03b9a66299ce7ccf3ef2900abc81c0db434f42a5694a37bd73870f2",
-                "sha256:1bc330d9d29c7f06f003ab10e1eaced295e87940405afe1b110f2eb93a233588",
-                "sha256:1e0d612a17581b6616ff03c8e3d5eff7452f34655c901f75d62bd86449d9750e",
-                "sha256:23623166bfefe1487d81b698c423f8678e80df8b54614c2bf4b4cfcd7c711959",
-                "sha256:2519f3a5d0517fc159afab1015e54bb81b4406c278749779be57a569d8d1bb0d",
-                "sha256:28120ef39c92c2dd60f2721af9328479516844c6b550b077ca450c7d7dc68575",
-                "sha256:37350015056a553e442ff672c2d20e6f4b6d0b2495691fa239d8aa18bb3bc908",
-                "sha256:39769a115f730d683b0eb7b694db9789267bcd027326cccc3125e862eb03bfd8",
-                "sha256:3c01117dd36800f2ecaa238c65365b7b16497adc1522bf84906e5710ee9ba0e8",
-                "sha256:3d6718667da04294d7df1670d70eeddd414f313738d20a6f1d1f379e3139a545",
-                "sha256:3dbb986bad3ed5ceaf090200eba750b5245150bd97d3e67343a3cfed06feecf7",
-                "sha256:4557e1f11c5f653ebfdd924f3f9d5ebfc718283b0b9beebaa5dd6b77ec290971",
-                "sha256:46331b00096a6db1fdc052d55b101dbbfc99155a548e20a0e4a8e5e4d1362855",
-                "sha256:4a121d62ebe7d26fec9155f83f8be5189ef1405f5973ea4874a26fab9f1e262c",
-                "sha256:4f5e9cd989b45b73bd359f693b935364f7e1f79486e29015813c338450aa5a71",
-                "sha256:50aae840ebbd6cdd41af1c14590e5741665e5272d2fee999306673a1bb1fdb4d",
-                "sha256:59b1ee96617135f6e1d6f275bbe988f419c5178016f3d41d3c0abb0c819f75bb",
-                "sha256:59b8f3adb3971929a3e660337f5dacc5942c2cdb760afcabb2614ffbda9f9f72",
-                "sha256:66bffbad8d6271bb1cc2f9a4ea4f86f80fe5e2e3e501a5ae2a3dc6a76e604e6f",
-                "sha256:69f93723edbca7342624d09f6704e7126b152eaed3cdbb634cb657a54332a3c5",
-                "sha256:6a440293d802d3011028e14e4226da1434b373cbaf4a4bbb63f845761a708346",
-                "sha256:72c28b84b174ce8af8504ca28ae9347d317f9dba3999e5981a3cd441f3712e24",
-                "sha256:79d2e78abc26d871875b419e1fd3c0bca31a1cb0043277d0d850014599626c2e",
-                "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5",
-                "sha256:8318f4776c85abc3f40ab185e388bee7a6ea99e7fa3a30686580b209eaa35c08",
-                "sha256:8958b10490125124463095bbdadda5aa22ec799f91958e410438ad6c97a7b793",
-                "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88",
-                "sha256:90812a8933df713fdf748b355527e3af257a11e415b613dd794512461eb8a686",
-                "sha256:9bc633f4ee4b4c46e7adcb3a9b5ec083bf1d9a97c1d3854b92749d935de40b9b",
-                "sha256:9e46ed38affdfc95d2c958de328d037d87801cfcbea6d421000859e9789e61c2",
-                "sha256:9fe53b404f24789b5ea9003fc25b9a3988feddebd7e7b369c8fac27ad6f52f28",
-                "sha256:a4e46a888b54be23d03a89be510f24a7652fe6ff660787b96cd0e57a4ebcb46d",
-                "sha256:a86bfab2ef46d63300c0f06936bd6e6c0105faa11d509083ba8f2f9d237fb5b5",
-                "sha256:ac9dfa18ff2a67b09b372d5db8743c27966abf0e5344c555d86cc7199f7ad83a",
-                "sha256:af148a33ff0349f53512a049c6406923e4e02bf2f26c5fb285f143faf4f0e46a",
-                "sha256:b11d0cfdd2b095e7b0686cf5fabeb9c67fae5b06d265d8180715b8cfa86522e3",
-                "sha256:b2985c0b06e989c043f1dc09d4fe89e1616aadd35392aea2844f0458a989eacf",
-                "sha256:b544ad1935a8541d177cb402948b94e871067656b3a0b9e91dbec136b06a2ff5",
-                "sha256:b5cc79df7f4bc3d11e4b542596c03826063092611e481fcf1c9dfee3c94355ef",
-                "sha256:b817d41d692bf286abc181f8af476c4fbef3fd05e798777492618378448ee689",
-                "sha256:b81ee3d84803fd42d0b154cb6892ae57ea6b7c55d8359a02379965706c7efe6c",
-                "sha256:be9812b766cad94a25bc63bec11f88c4ad3629a0cec1cd5d4ba48dc23860486b",
-                "sha256:c245b1fbade9c35e5bd3b64270ab49ce990369018289ecfde3f9c318411aaa07",
-                "sha256:c3f3631693003d8e585d4200730616b78fafd5a01ef8b698f6967da5c605b3fa",
-                "sha256:c4ae3005ed83f5967f961fd091f2f8c5329161f69ce8480aa8168b2d7fe37f06",
-                "sha256:c54a1e53a0c308a8e8a7dffb59097bff7facda27c70c286f005327f21b2bd6b1",
-                "sha256:d0ddd9db6e59c44875211bc4c7953a9f6638b937b0a88ae6d09eb46cced54eff",
-                "sha256:dc022184d3e5cacc9579e41805a681187650e170eb2fd70e28b86192a479dcaa",
-                "sha256:e32092c47011d113dc01ab3e1d3ce9f006a47223b18422c5c0d150af13a00687",
-                "sha256:f7b64e6ec3f02c35647be6b4851008b26cff592a95ecb13b6788a54ef80bbdd4",
-                "sha256:f942a799516184c855e1a32fbc7b29d7e571b52612647866d4ec1c3242578fcb",
-                "sha256:f9511d8dd4a6e9271d07d150fb2f81874a3c8c95e11ff9af3a2dfc35fe42ee44",
-                "sha256:fd3a55deef00f689ce931d4d1b23fa9f04c880a48ee97af488fd215cf24e2a6c",
-                "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e",
-                "sha256:fdf3386a801ea5aba17c6410dd1dc8d39cf454ca2565541b5ac42a84e1e28f53"
+                "sha256:018ee97c558b499b58935c5a152aeabf6d36b3d55d91656abeb6d93d663c0c4c",
+                "sha256:01da15490c9df352fbc29859d3c7ba9cd1377791faeeb47c100832004c99472c",
+                "sha256:04545042969833cb92e13b0a3019549d284fd2423f318b6ba10e7aa687690a3c",
+                "sha256:06205eb98cb3dd52133ca6818bf5542397f1dd1b69f7ea28aa84413897380b06",
+                "sha256:08cf721bbd4391a0e765fe0fe8816e81d9f43cece54fdb5ac465c56efafecb3d",
+                "sha256:0d7e3866eb52d914aea50c9be74184a0feb86f9af8aaaa4daefe52b69378db0b",
+                "sha256:125a7763b263218a80759ad9ae2f3610aaf2c2fbbd78fff088d584edf81f3782",
+                "sha256:23c5aa33c01bd898f879db158537d7e7568b503b15aad60ea0c8da8109adf3e7",
+                "sha256:2600a50d590c22d99c424c394236899ba72f849a02b10e65b4c70149606408b5",
+                "sha256:2d7332868ce891eda48896131991f7f2be572d65b41a4050957242f8e935d5d7",
+                "sha256:2ed107331d188a286611cea9022de0afc437dd2d3c168e368169f27aa0f61338",
+                "sha256:3395e7ed89c6d264d38bea3bfb22ffe868f906a7985d03546ec7dc30221ea980",
+                "sha256:344cd1ec2b3c6bdd5dfde7ba7e3b879e0f8dd44181f16b895940be9b842fd2b6",
+                "sha256:34d5c49f18778a3665d707e6286545a30339ad545950773d43977e504815fa70",
+                "sha256:35e72518615aa5384ef4fae828e3af1b43102458b74a8c481f69af8abf7e802a",
+                "sha256:3eb14ba1a9d07c88669b7faf8f589be67871d6409305e73e036321d89f1d904e",
+                "sha256:412c6c126369ddae171c13987b38df5122cb92015cba6f9ee1193b867f3f1530",
+                "sha256:4600c7a659d381146e1160235918826c50c80994e07c5b26946a3e7ec6c99249",
+                "sha256:463ecfb907b256e94bfe7bcb31a6d8c7bc96eca7cbe39803e448a58bb9fcad02",
+                "sha256:4a06e6c8e31c98ddc770734c63903e39f1947c9e3e5e4bef515c5491b7737dde",
+                "sha256:4b2de1523d46e7016afc7e42db239bd41f2163316935de7c84d0e19af7e69538",
+                "sha256:4dabd775fd66cf17f31f8625fc0e4cfc5765f7982f94dc09b9e5868182cb71c0",
+                "sha256:4eff9c270afd23e2746e921e80182872058a7a592017b2713f33f96cc5f82e32",
+                "sha256:52607d0ebea43cf214e2ee84a6a76bc774176f97c5a774ce33277514875a718e",
+                "sha256:533e0f66c32093a987a30df3ad6ed21170db9d581d0b38e71396c49718fbb1ca",
+                "sha256:5493a8120d6fc185f60e7254fc056a6742f1db68c0f849cfc9ab46163c21df47",
+                "sha256:5d2d1fe548def3267b4c70a8568f108d1fed7cbbeccb9cc166e05af2abc25c22",
+                "sha256:5dfbc543578058c340360f851ddcecd7a1e26b0d9b5b69259b526da9edfa8875",
+                "sha256:66a40003bc244e4ad86b72abb9965d304726d05a939e8c09ce844d27af9e6d37",
+                "sha256:67de057fbcb04a066171bd9ee6bcb58738d89378ee3cabff0bffbf343ae1c787",
+                "sha256:6827f8c1b2f13f1420545bd6d5b3f9e0b85fe750388425be53d23c760dcf176b",
+                "sha256:6b35e07f1d57b79b86a7de8ecdcefb78485dab9851b9638c2c793c50203b2ae8",
+                "sha256:7399d45b62d755e9ebba94eb89437f80512c08edde8c63716552a3aade61eb42",
+                "sha256:788b6ff6728072b313802be13e88113c33696a9a1f2f6d634a97c20f7ef5ccce",
+                "sha256:78f1b79132a69fe8bd6b5d91ef433c8eb40688ba782b26f8c9f3d2d9ca23626f",
+                "sha256:79f4f502125a41b1b3b34449e747a6abfd52a709d539ea7769101696bdca6716",
+                "sha256:7a8517b6d4005facdbd7eb4e8cf54797dbca100a7df459fdaff4c5123265c1cd",
+                "sha256:7bd5c5ee1448b6408734eaa29c0d820d061ae18cb17232ce37848376dcfa3e92",
+                "sha256:7f5243357e6da9a90c56282f64b50d29cba2ee1f745381174caacc50d501b109",
+                "sha256:805cb481474e111ee3687c9047c5f3286e62496f09c0e82e8853338aaaa348f8",
+                "sha256:871f55e478b5a648c08dd24af44345406d0e636ffe021d64c9b57a4a11518304",
+                "sha256:87a1ce1f5e5dc4b6f4e0aac34e7bb535cb23bd4f5d9c799ed1633b65c2bcad8c",
+                "sha256:8a10ca7f8a1ea0fd5630f02feb055b0f5cdfcd07bb3715fc1b6f8cb72bf114e4",
+                "sha256:995c2bacdddcb640c2ca558e6760383dcdd68830160af92b5c6e6928ffd259b4",
+                "sha256:9f03143f8f851dd8de6b0c10784363712058f38209e926723c80654c1b40327a",
+                "sha256:a1c6b0a5e3e326a466d809b651c63f278b1256146a377a528b6938a279da334f",
+                "sha256:a28f9c238f1e143ff42ab3ba27990dfb964e5d413c0eb001b88794c5c4a528a9",
+                "sha256:b2cf5b5ddb69142511d5559c427ff00ec8c0919a1e6c09486e9c32636ea2b9dd",
+                "sha256:b761a6847f96fdc2d002e29e9e9ac2439c13b919adfd64e8ef49e75f6355c548",
+                "sha256:bf555f3e25ac3a70c67807b2949bfe15f377a40df84b71ab2c58d8593a1e036e",
+                "sha256:c08a972cbac2a14810463aec3a47ff218bb00c1a607e6689b531a7c589c50723",
+                "sha256:c457a38351fb6234781d054260c60e531047e4d07beca1889b558ff73dc2014b",
+                "sha256:c4c433f78c2908ae352848f56589c02b982d0e741b7905228fad628999799de4",
+                "sha256:d9f119e7736967c0ea03aff91ac7d04555ee038caf89bb855d93bbd04ae85b41",
+                "sha256:e6b0a1c7ed54a5361aaebb910c1fa864bae34273662bb4ff788a527eafd6e14d",
+                "sha256:f2bcb085faffcacf9319b1b1445a7e1cfdc6fb46c03f2dce7bc2d9a4b3c1cdc5",
+                "sha256:fe193d3ae297c423e0e567e240b4324d6b6c280a048e64c77a3ea6886cc2aa87"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.36"
+            "version": "==2.0.39"
         },
         "typing-extensions": {
             "hashes": [
@@ -311,131 +389,57 @@
     "develop": {
         "black": {
             "hashes": [
-                "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474",
-                "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1",
-                "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0",
-                "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8",
-                "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96",
-                "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1",
-                "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04",
-                "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021",
-                "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94",
-                "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d",
-                "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c",
-                "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7",
-                "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c",
-                "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc",
-                "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7",
-                "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d",
-                "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c",
-                "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741",
-                "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce",
-                "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb",
-                "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063",
-                "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"
+                "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
+                "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7",
+                "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da",
+                "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2",
+                "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc",
+                "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666",
+                "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f",
+                "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b",
+                "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32",
+                "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f",
+                "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717",
+                "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299",
+                "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0",
+                "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18",
+                "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0",
+                "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3",
+                "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355",
+                "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096",
+                "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e",
+                "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9",
+                "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba",
+                "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==24.4.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==25.1.0"
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
-        },
-        "coverage": {
-            "extras": [
-                "toml"
-            ],
-            "hashes": [
-                "sha256:0086cd4fc71b7d485ac93ca4239c8f75732c2ae3ba83f6be1c9be59d9e2c6382",
-                "sha256:01c322ef2bbe15057bc4bf132b525b7e3f7206f071799eb8aa6ad1940bcf5fb1",
-                "sha256:03cafe82c1b32b770a29fd6de923625ccac3185a54a5e66606da26d105f37dac",
-                "sha256:044a0985a4f25b335882b0966625270a8d9db3d3409ddc49a4eb00b0ef5e8cee",
-                "sha256:07ed352205574aad067482e53dd606926afebcb5590653121063fbf4e2175166",
-                "sha256:0d1b923fc4a40c5832be4f35a5dab0e5ff89cddf83bb4174499e02ea089daf57",
-                "sha256:0e7b27d04131c46e6894f23a4ae186a6a2207209a05df5b6ad4caee6d54a222c",
-                "sha256:1fad32ee9b27350687035cb5fdf9145bc9cf0a094a9577d43e909948ebcfa27b",
-                "sha256:289cc803fa1dc901f84701ac10c9ee873619320f2f9aff38794db4a4a0268d51",
-                "sha256:3c59105f8d58ce500f348c5b56163a4113a440dad6daa2294b5052a10db866da",
-                "sha256:46c3d091059ad0b9c59d1034de74a7f36dcfa7f6d3bde782c49deb42438f2450",
-                "sha256:482855914928c8175735a2a59c8dc5806cf7d8f032e4820d52e845d1f731dca2",
-                "sha256:49c76cdfa13015c4560702574bad67f0e15ca5a2872c6a125f6327ead2b731dd",
-                "sha256:4b03741e70fb811d1a9a1d75355cf391f274ed85847f4b78e35459899f57af4d",
-                "sha256:4bea27c4269234e06f621f3fac3925f56ff34bc14521484b8f66a580aacc2e7d",
-                "sha256:4d5fae0a22dc86259dee66f2cc6c1d3e490c4a1214d7daa2a93d07491c5c04b6",
-                "sha256:543ef9179bc55edfd895154a51792b01c017c87af0ebaae092720152e19e42ca",
-                "sha256:54dece71673b3187c86226c3ca793c5f891f9fc3d8aa183f2e3653da18566169",
-                "sha256:6379688fb4cfa921ae349c76eb1a9ab26b65f32b03d46bb0eed841fd4cb6afb1",
-                "sha256:65fa405b837060db569a61ec368b74688f429b32fa47a8929a7a2f9b47183713",
-                "sha256:6616d1c9bf1e3faea78711ee42a8b972367d82ceae233ec0ac61cc7fec09fa6b",
-                "sha256:6fe885135c8a479d3e37a7aae61cbd3a0fb2deccb4dda3c25f92a49189f766d6",
-                "sha256:7221f9ac9dad9492cecab6f676b3eaf9185141539d5c9689d13fd6b0d7de840c",
-                "sha256:76d5f82213aa78098b9b964ea89de4617e70e0d43e97900c2778a50856dac605",
-                "sha256:7792f0ab20df8071d669d929c75c97fecfa6bcab82c10ee4adb91c7a54055463",
-                "sha256:831b476d79408ab6ccfadaaf199906c833f02fdb32c9ab907b1d4aa0713cfa3b",
-                "sha256:9146579352d7b5f6412735d0f203bbd8d00113a680b66565e205bc605ef81bc6",
-                "sha256:9cc44bf0315268e253bf563f3560e6c004efe38f76db03a1558274a6e04bf5d5",
-                "sha256:a73d18625f6a8a1cbb11eadc1d03929f9510f4131879288e3f7922097a429f63",
-                "sha256:a8659fd33ee9e6ca03950cfdcdf271d645cf681609153f218826dd9805ab585c",
-                "sha256:a94925102c89247530ae1dab7dc02c690942566f22e189cbd53579b0693c0783",
-                "sha256:ad4567d6c334c46046d1c4c20024de2a1c3abc626817ae21ae3da600f5779b44",
-                "sha256:b2e16f4cd2bc4d88ba30ca2d3bbf2f21f00f382cf4e1ce3b1ddc96c634bc48ca",
-                "sha256:bbdf9a72403110a3bdae77948b8011f644571311c2fb35ee15f0f10a8fc082e8",
-                "sha256:beb08e8508e53a568811016e59f3234d29c2583f6b6e28572f0954a6b4f7e03d",
-                "sha256:c4cbe651f3904e28f3a55d6f371203049034b4ddbce65a54527a3f189ca3b390",
-                "sha256:c7b525ab52ce18c57ae232ba6f7010297a87ced82a2383b1afd238849c1ff933",
-                "sha256:ca5d79cfdae420a1d52bf177de4bc2289c321d6c961ae321503b2ca59c17ae67",
-                "sha256:cdab02a0a941af190df8782aafc591ef3ad08824f97850b015c8c6a8b3877b0b",
-                "sha256:d17c6a415d68cfe1091d3296ba5749d3d8696e42c37fca5d4860c5bf7b729f03",
-                "sha256:d39bd10f0ae453554798b125d2f39884290c480f56e8a02ba7a6ed552005243b",
-                "sha256:d4b3cd1ca7cd73d229487fa5caca9e4bc1f0bca96526b922d61053ea751fe791",
-                "sha256:d50a252b23b9b4dfeefc1f663c568a221092cbaded20a05a11665d0dbec9b8fb",
-                "sha256:da8549d17489cd52f85a9829d0e1d91059359b3c54a26f28bec2c5d369524807",
-                "sha256:dcd070b5b585b50e6617e8972f3fbbee786afca71b1936ac06257f7e178f00f6",
-                "sha256:ddaaa91bfc4477d2871442bbf30a125e8fe6b05da8a0015507bfbf4718228ab2",
-                "sha256:df423f351b162a702c053d5dddc0fc0ef9a9e27ea3f449781ace5f906b664428",
-                "sha256:dff044f661f59dace805eedb4a7404c573b6ff0cdba4a524141bc63d7be5c7fd",
-                "sha256:e7e128f85c0b419907d1f38e616c4f1e9f1d1b37a7949f44df9a73d5da5cd53c",
-                "sha256:ed8d1d1821ba5fc88d4a4f45387b65de52382fa3ef1f0115a4f7a20cdfab0e94",
-                "sha256:f2501d60d7497fd55e391f423f965bbe9e650e9ffc3c627d5f0ac516026000b8",
-                "sha256:f7db0b6ae1f96ae41afe626095149ecd1b212b424626175a6633c2999eaad45b"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==7.6.0"
-        },
-        "csp-report-collector": {
-            "editable": true,
-            "file": "."
+            "version": "==8.1.8"
         },
         "flake8": {
             "hashes": [
-                "sha256:2e416edcc62471a64cea09353f4e7bdba32aeb079b6e360554c659a122b1bc6a",
-                "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
+                "sha256:1cbc62e65536f65e6d754dfe6f1bada7f5cf392d6f5db3c2b85892466c3e7c1a",
+                "sha256:c586ffd0b41540951ae41af572e6790dbd49fc12b3aa2541685d253d9bd504bd"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.8.1'",
-            "version": "==7.1.0"
+            "version": "==7.1.2"
         },
         "iniconfig": {
             "hashes": [
-                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
-                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+                "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7",
+                "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
-        },
-        "isort": {
-            "hashes": [
-                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
-                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
-            ],
-            "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==5.13.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.1.0"
         },
         "mccabe": {
             "hashes": [
@@ -444,14 +448,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
-        },
-        "mongomock": {
-            "hashes": [
-                "sha256:08a24938a05c80c69b6b8b19a09888d38d8c6e7328547f94d46cadb7f47209f2",
-                "sha256:f06cd62afb8ae3ef63ba31349abd220a657ef0dd4f0243a29587c5213f931b7d"
-            ],
-            "index": "pypi",
-            "version": "==4.1.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -463,11 +459,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.1"
+            "version": "==24.2"
         },
         "pathspec": {
             "hashes": [
@@ -479,11 +475,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
-                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
+                "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94",
+                "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==4.2.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==4.3.7"
         },
         "pluggy": {
             "hashes": [
@@ -495,11 +491,11 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:442f950141b4f43df752dd303511ffded3a04c2b6fb7f65980574f0c31e6e79c",
-                "sha256:949a39f6b86c3e1515ba1787c2022131d165a8ad271b11370a8819aa070269e4"
+                "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3",
+                "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.12.0"
+            "version": "==2.12.1"
         },
         "pyflakes": {
             "hashes": [
@@ -511,53 +507,21 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343",
-                "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
+                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
+                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.2.2"
-        },
-        "pytest-cov": {
-            "hashes": [
-                "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652",
-                "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==5.0.0"
-        },
-        "pytest-dotenv": {
-            "hashes": [
-                "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732",
-                "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f"
-            ],
-            "index": "pypi",
-            "version": "==0.5.2"
-        },
-        "python-dotenv": {
-            "hashes": [
-                "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
-                "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==1.0.1"
+            "version": "==8.3.5"
         },
         "semver": {
             "hashes": [
-                "sha256:6253adb39c70f6e51afed2fa7152bcd414c411286088fb4b9effb133885ab4cc",
-                "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"
+                "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746",
+                "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.0.2"
-        },
-        "sentinels": {
-            "hashes": [
-                "sha256:7be0704d7fe1925e397e92d18669ace2f619c92b5d4eb21a89f31e026f9ff4b1"
-            ],
-            "version": "==1.0.0"
+            "version": "==3.0.4"
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,9 @@ line_length = 256
 float_to_top = "true"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-#addopts = "-q --cov=src --cov-fail-under=100 --cov-report html --cov-report term-missing --no-cov-on-fail"
-addopts = "-q --cov=src --cov-report html --cov-report term-missing"
-env_files = [
-    ".testenv"
-]
-env_override_existing_values = 1
+pythonpath = "src"
+minversion = "8.0"
+addopts = "-vv --import-mode=append"
 filterwarnings = [
     #"ignore:'pipes' is deprecated:DeprecationWarning",
     "ignore:pkg_resources is deprecated:DeprecationWarning",

--- a/src/csp_datamodel.py
+++ b/src/csp_datamodel.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import URL, Enum
+from typing import Literal
+from typing import get_args
+
+
+ReportDisposition = Literal["enforce", "report"]
+
+class BaseModel(DeclarativeBase):
+        __abstract__ = True  # So SQLAlchemy doesn't create this as a table
+        pass
+
+class ReportsModel(BaseModel):
+    __tablename__ = "reports"
+
+    '''
+    csp report can be in one of two forms:
+    - The legacy `report-uri` format which is simplified json
+        - Content-Type: application/csp-report
+        - CSP 'report-uri' directive
+    {
+        "csp-report":
+        {
+            "blocked-uri": "The URI of the resource that was blocked from loading by the Content Security Policy.",
+            "disposition": 'Either "enforce" or "report" depending on whether the Content-Security-Policy-Report-Only header or the Content-Security-Policy header is used',
+            "document-uri": "The URI of the document in which the violation occurred."
+            "effective-directive": "The directive whose enforcement caused the violation. eg 'style-src'".
+            "original-policy": "The CSP policy from the header".
+            "referrer": "The referrer of the document in which the violation occurred".
+            "script-sample": "The first 40 characters of the inline script, event handler, or style that caused the violation.  Only relevant when 'report-sample' is used in policy".
+            "status-code": "The HTTP status code of the resource on which the global object was instantiated.",
+            "violated-directive": "The directive whose enforcement caused the violation. The violated-directive is a historic name for the effective-directive field and contains the same value."
+        }
+    }
+
+    - The more complex CSPViolationReportBody that is a subcomponent of the Reporting API
+        - Content-Type: application/reports+json
+        - CSP 'report-to' directive
+    {
+        "age": 53531,
+        "body": {
+            "blockedURL": "inline",
+            "columnNumber": 39,
+            "disposition": "enforce",
+            "documentURL": "https://example.com/violating/page",
+            "effectiveDirective": "script-src-elem",
+            "lineNumber": 121,
+            "originalPolicy": "default-src 'self'; report-to csp-endpoint-name",
+            "referrer": "https://www.examplesearchengine.com/",
+            "sample": "console.log(\"lo\")",
+            "sourceFile": "https://example.com/csp-report",
+            "statusCode": 200
+        },
+        "type": "csp-violation",
+        "url": "https://example.com/csp-report",
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
+    }
+    '''
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    domain: Mapped[str] = mapped_column(nullable=False, index=True)
+    document_uri: Mapped[str] = mapped_column(nullable=False, index=True)
+    blocked_uri: Mapped[str] = mapped_column(nullable=False, index=True)
+    effective_directive: Mapped[str] = mapped_column(nullable=False, index=True)
+    status_code: Mapped[int] = mapped_column(nullable=False)
+    disposition: Mapped[ReportDisposition] = mapped_column(Enum(
+        *get_args(ReportDisposition),
+        name="disposition",
+        create_constraint=True,
+        validate_strings=True
+    ), nullable=False)
+    original_policy: Mapped[str] = mapped_column(nullable=False)
+    line_number: Mapped[int] = mapped_column(nullable=True)
+    column_number: Mapped[int] = mapped_column(nullable=True)
+    sample: Mapped[str] = mapped_column(nullable=True)
+    referrer: Mapped[str] = mapped_column(nullable=True)
+    user_agent: Mapped[str] = mapped_column(nullable=True)
+    reported_at: Mapped[datetime] = mapped_column(nullable=False)

--- a/src/csp_datamodel.py
+++ b/src/csp_datamodel.py
@@ -61,7 +61,7 @@ class ReportsModel(BaseModel):
     id: Mapped[int] = mapped_column(primary_key=True)
     domain: Mapped[str] = mapped_column(nullable=False, index=True)
     document_uri: Mapped[str] = mapped_column(nullable=False, index=True)
-    blocked_uri: Mapped[str] = mapped_column(nullable=False, index=True)
+    blocked_uri: Mapped[str] = mapped_column(nullable=True, index=True)
     effective_directive: Mapped[str] = mapped_column(nullable=False, index=True)
     status_code: Mapped[int] = mapped_column(nullable=False)
     disposition: Mapped[ReportDisposition] = mapped_column(Enum(

--- a/src/csp_datamodel.py
+++ b/src/csp_datamodel.py
@@ -7,14 +7,16 @@ from typing import get_args
 
 ReportDisposition = Literal["enforce", "report"]
 
+
 class BaseModel(DeclarativeBase):
-        __abstract__ = True  # So SQLAlchemy doesn't create this as a table
-        pass
+    __abstract__ = True  # So SQLAlchemy doesn't create this as a table
+    pass
+
 
 class ReportsModel(BaseModel):
     __tablename__ = "reports"
 
-    '''
+    """
     csp report can be in one of two forms:
     - The legacy `report-uri` format which is simplified json
         - Content-Type: application/csp-report
@@ -56,7 +58,7 @@ class ReportsModel(BaseModel):
         "url": "https://example.com/csp-report",
         "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
     }
-    '''
+    """
 
     id: Mapped[int] = mapped_column(primary_key=True)
     domain: Mapped[str] = mapped_column(nullable=False, index=True)
@@ -64,12 +66,7 @@ class ReportsModel(BaseModel):
     blocked_uri: Mapped[str] = mapped_column(nullable=True, index=True)
     effective_directive: Mapped[str] = mapped_column(nullable=False, index=True)
     status_code: Mapped[int] = mapped_column(nullable=False)
-    disposition: Mapped[ReportDisposition] = mapped_column(Enum(
-        *get_args(ReportDisposition),
-        name="disposition",
-        create_constraint=True,
-        validate_strings=True
-    ), nullable=False)
+    disposition: Mapped[ReportDisposition] = mapped_column(Enum(*get_args(ReportDisposition), name="disposition", create_constraint=True, validate_strings=True), nullable=False)
     original_policy: Mapped[str] = mapped_column(nullable=False)
     line_number: Mapped[int] = mapped_column(nullable=True)
     column_number: Mapped[int] = mapped_column(nullable=True)

--- a/src/csp_report_collector.py
+++ b/src/csp_report_collector.py
@@ -157,6 +157,12 @@ def display_csp_reports():
     reports = db.paginate(db.select(csp_datamodel.ReportsModel).order_by(csp_datamodel.ReportsModel.reported_at),page=pagenum,per_page=pagesize,max_per_page=100)
     return render_template("reports.jinja", reports=reports)
 
+@app.route("/reports/<int:id>", methods=["GET"])
+def display_single_report(id: int):
+    db: SQLAlchemy = app.config["db"]
+    report = db.session.execute(db.select(csp_datamodel.ReportsModel).filter_by(id=id)).scalar_one()
+    return render_template("reports_detail.jinja", report=report)
+
 @app.route("/status")
 def status():
     return make_response("ok", 200)

--- a/src/csp_report_collector.py
+++ b/src/csp_report_collector.py
@@ -143,7 +143,7 @@ def csp_receiver():
 
     try:
         if app.config["db"]:
-            csp_report.write(db)
+            csp_report.write(db.session)
     except Exception as e:
         abort(500, e)
 

--- a/src/csp_report_collector.py
+++ b/src/csp_report_collector.py
@@ -184,9 +184,12 @@ def csp_receiver():
 
 @app.route("/reports",methods=["GET"])
 def csp_reports():
-    db = app.config["db"]
-    reports = db.session.execute(db.select(ReportsModel).order_by(ReportsModel.reported_at)).scalars()
+    pagenum: int = int(request.args.get("p", 1))
+    pagesize: int = 50
+    db: SQLAlchemy = app.config["db"]
+    reports = db.paginate(db.select(ReportsModel).order_by(ReportsModel.reported_at),page=pagenum,per_page=pagesize,max_per_page=100)
     return render_template("reports.jinja", reports=reports)
+
 
 def _write_to_database(
     db: SQLAlchemy,

--- a/src/csp_report_collector.py
+++ b/src/csp_report_collector.py
@@ -30,6 +30,7 @@ logging.basicConfig(
 
 ### Private Functions ###
 
+
 def _load_config(config_path: Optional[str] = "settings.conf", env_prefix: str = "CSPRC") -> dict:
     ## Initialise supported variables
     config: dict[str, Optional[str]] = {
@@ -104,30 +105,35 @@ app.config["db"] = db
 
 ### Flask Handlers ###
 
+
 @app.errorhandler(400)  # 400 Bad Request
 def error_400(error):
     app.logger.warning(f"Error[400]: {error}")
     return make_response(jsonify({"error": str(error)}), 400)
 
+
 @app.errorhandler(404)  # 404 Not Found
 def error_404(error):
     return make_response(jsonify({"error": str(error)}), 404)
+
 
 @app.errorhandler(405)  # 405 Method Not Allowed
 def error_405(error):
     return make_response(jsonify({"error": str(error)}), 405)
 
-@app.errorhandler(500) # 500 Internal Server Error
+
+@app.errorhandler(500)  # 500 Internal Server Error
 def error_500(error):
     app.logger.error(f"Error[500]: {error}")
     return make_response(jsonify({"error": "Unable to handle request.  See logs for details."}))
 
+
 @app.route("/csp-report", methods=["POST"])
 def csp_receiver():
     ## https://junxiandoc.readthedocs.io/en/latest/docs/flask/flask_request_response.html
-    
+
     report_json = request.get_json(force=True)
-    app.logger.debug(f"{datetime.now()} {request.remote_addr} {request.content_type} {report_json}") 
+    app.logger.debug(f"{datetime.now()} {request.remote_addr} {request.content_type} {report_json}")
 
     if not request.content_type in csp_reports.csp_content_type:
         abort(400, f"Invalid content type. Expected one of {" ".join(csp_reports.csp_content_type)}, got '{request.content_type}'.")
@@ -149,19 +155,22 @@ def csp_receiver():
 
     return make_response(jsonify({}), 204)
 
-@app.route("/reports",methods=["GET"])
+
+@app.route("/reports", methods=["GET"])
 def display_csp_reports():
     pagenum: int = int(request.args.get("p", 1))
     pagesize: int = 50
     db: SQLAlchemy = app.config["db"]
-    reports = db.paginate(db.select(csp_datamodel.ReportsModel).order_by(csp_datamodel.ReportsModel.reported_at),page=pagenum,per_page=pagesize,max_per_page=100)
+    reports = db.paginate(db.select(csp_datamodel.ReportsModel).order_by(csp_datamodel.ReportsModel.reported_at), page=pagenum, per_page=pagesize, max_per_page=100)
     return render_template("reports.jinja", reports=reports)
+
 
 @app.route("/reports/<int:id>", methods=["GET"])
 def display_single_report(id: int):
     db: SQLAlchemy = app.config["db"]
     report = db.session.execute(db.select(csp_datamodel.ReportsModel).filter_by(id=id)).scalar_one()
     return render_template("reports_detail.jinja", report=report)
+
 
 @app.route("/status")
 def status():

--- a/src/csp_report_collector.py
+++ b/src/csp_report_collector.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
-import html
 import json
 import logging
 import os
+import csp_reports, csp_datamodel
 from datetime import datetime
 from typing import Optional
-from urllib.parse import urlparse
 
 import dotenv
-from flask import Flask, abort, jsonify, make_response, request, render_template
+from flask import Flask, abort, jsonify, make_response, request, render_template, Response
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import URL
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-__version__ = "0.5.0"
+__version__ = "1.0.0"
 
 SUPPORTED_DB_ENGINES = [
     "mariadb",
@@ -27,13 +25,10 @@ dotenv.load_dotenv()
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s]: %(name)s:%(lineno)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
 )
 
-log = logging.getLogger("werkzeug")
-
-
 ### Private Functions ###
-
 
 def _load_config(config_path: Optional[str] = "settings.conf", env_prefix: str = "CSPRC") -> dict:
     ## Initialise supported variables
@@ -90,20 +85,6 @@ db = None
 
 if app.config["db_type"]:
 
-    class BaseModel(DeclarativeBase):
-        __abstract__ = True  # So SQLAlchemy doesn't create this as a table
-        pass
-
-    class ReportsModel(BaseModel):
-        __tablename__ = "reports"
-
-        id: Mapped[int] = mapped_column(primary_key=True)
-        domain: Mapped[str] = mapped_column(nullable=False, index=True)
-        document_uri: Mapped[str] = mapped_column(nullable=False, index=True)
-        blocked_uri: Mapped[str] = mapped_column(nullable=False, index=True)
-        violated_directive: Mapped[str] = mapped_column(nullable=False, index=True)
-        reported_at: Mapped[datetime] = mapped_column(nullable=False)
-
     app.config["SQLALCHEMY_DATABASE_URI"] = URL.create(
         drivername=app.config["db_type"],
         username=app.config["db_username"],
@@ -113,7 +94,7 @@ if app.config["db_type"]:
         database=app.config["db_name"],
     )
 
-    db = SQLAlchemy(model_class=BaseModel)
+    db = SQLAlchemy(model_class=csp_datamodel.BaseModel)
     db.init_app(app)
 
     with app.app_context():
@@ -123,93 +104,58 @@ app.config["db"] = db
 
 ### Flask Handlers ###
 
-
 @app.errorhandler(400)  # 400 Bad Request
 def error_400(error):
+    app.logger.warning(f"Error[400]: {error}")
     return make_response(jsonify({"error": str(error)}), 400)
-
 
 @app.errorhandler(404)  # 404 Not Found
 def error_404(error):
     return make_response(jsonify({"error": str(error)}), 404)
 
-
 @app.errorhandler(405)  # 405 Method Not Allowed
 def error_405(error):
     return make_response(jsonify({"error": str(error)}), 405)
 
+@app.errorhandler(500) # 500 Internal Server Error
+def error_500(error):
+    app.logger.error(f"Error[500]: {error}")
+    return make_response(jsonify({"error": "Unable to handle request.  See logs for details."}))
 
-@app.route("/", methods=["POST"])
+@app.route("/csp-report", methods=["POST"])
 def csp_receiver():
     ## https://junxiandoc.readthedocs.io/en/latest/docs/flask/flask_request_response.html
-    csp_content_type =  ["application/csp-report", "application/reports+json"]
-    if not request.content_type in csp_content_type:
-        abort(400, f"Invalid content type. Expected one of {" ".join(csp_content_type)}, got '{request.content_type}'.")
+    
+    report_json = request.get_json(force=True)
+    app.logger.debug(f"{datetime.now()} {request.remote_addr} {request.content_type} {report_json}") 
 
-    csp_report = json.loads(request.data.decode("UTF-8"))["csp-report"]
-    log.info(f"{datetime.now()} {request.remote_addr} {request.content_type} {csp_report}")
+    if not request.content_type in csp_reports.csp_content_type:
+        abort(400, f"Invalid content type. Expected one of {" ".join(csp_reports.csp_content_type)}, got '{request.content_type}'.")
 
+        csp_report: csp_reports.CSPReport
     try:
-        blocked_uri = html.escape(csp_report["blocked-uri"], quote=True).split(" ", 1)[0]
-    except AttributeError:
-        blocked_uri = None
-
-    document_uri = html.escape(csp_report["document-uri"], quote=True).split(" ", 1)[0]
-    violated_directive = html.escape(csp_report["violated-directive"], quote=True).split(" ", 1)[0]
-
-    domain = urlparse(document_uri).hostname
-
-    ## Short-ciruit reports for 'about' pages, i.e. about:config, etc.
-    if blocked_uri == "about" or document_uri == "about":
+        csp_report = csp_reports.get_report(report_json)
+    except csp_reports.RequiredElementMissingError as err:
+        app.logger.warning(f"Unable to parse report ({err.__class__.__name__}): {err}")
+        abort(400, err)
+    except csp_reports.AboutException:
         return make_response(jsonify({}), 204)
 
-    elif not blocked_uri:
-        if violated_directive == "script-src":
-            blocked_uri = "eval"
-
-        elif violated_directive == "style-src":
-            blocked_uri = "inline"
-
-    if app.config["db"]:
-        _write_to_database(
-            db=app.config["db"],
-            reported_at=datetime.utcnow(),
-            domain=domain,
-            document_uri=document_uri,
-            blocked_uri=str(blocked_uri),
-            violated_directive=violated_directive,
-        )
+    try:
+        if app.config["db"]:
+            csp_report.write(db)
+    except Exception as e:
+        abort(500, e)
 
     return make_response(jsonify({}), 204)
 
 @app.route("/reports",methods=["GET"])
-def csp_reports():
+def display_csp_reports():
     pagenum: int = int(request.args.get("p", 1))
     pagesize: int = 50
     db: SQLAlchemy = app.config["db"]
-    reports = db.paginate(db.select(ReportsModel).order_by(ReportsModel.reported_at),page=pagenum,per_page=pagesize,max_per_page=100)
+    reports = db.paginate(db.select(csp_datamodel.ReportsModel).order_by(csp_datamodel.ReportsModel.reported_at),page=pagenum,per_page=pagesize,max_per_page=100)
     return render_template("reports.jinja", reports=reports)
-
-
-def _write_to_database(
-    db: SQLAlchemy,
-    domain: str,
-    blocked_uri: str,
-    document_uri: str,
-    reported_at: datetime,
-    violated_directive: str,
-) -> None:
-    report = ReportsModel(
-        domain=domain,
-        document_uri=document_uri,
-        blocked_uri=blocked_uri,
-        violated_directive=violated_directive,
-        reported_at=reported_at,
-    )
-
-    db.session.add(report)
-    db.session.commit()
-
 
 @app.route("/status")
 def status():

--- a/src/csp_reports.py
+++ b/src/csp_reports.py
@@ -110,9 +110,9 @@ class ReportTo(CSPReport):
 
         try:
             if request_data["type"] != "csp-violation":
-                raise RequiredElementMissingError(f"Report type must be 'csp-violation' but got {request_data["type"]}")
+                raise InvalidReportType(f"Report type must be 'csp-violation' but got {request_data["type"]}")
         except KeyError:
-            raise InvalidReportType(f"Report is not a valid csp-violation report")
+            raise RequiredElementMissingError(f"Report is not a valid csp-violation report")
         
         try:
             self.user_agent = html.escape(request_data["user_agent"], quote=True)

--- a/src/csp_reports.py
+++ b/src/csp_reports.py
@@ -1,0 +1,191 @@
+import abc
+import html
+
+from csp_datamodel import ReportsModel
+
+from datetime import datetime, timezone
+from flask_sqlalchemy import SQLAlchemy
+from urllib.parse import urlparse
+
+
+class AboutException(Exception):
+    pass
+
+class RequiredElementMissingError(Exception):
+    pass
+
+class InvalidReportType(RequiredElementMissingError):
+    pass
+
+class CSPReport(abc.ABC):
+    def __init__(self,received: datetime):
+        self.received = received
+
+    @abc.abstractmethod
+    def write(self, db: SQLAlchemy):
+        pass
+
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri#violation_report_syntax
+# Officially deprecated
+class ReportURI(CSPReport):
+    def __init__(self, request_data: dict, received: datetime = datetime.now(timezone.utc)):
+        try:
+            csp_report = request_data["csp-report"]
+        except KeyError:
+            raise InvalidReportType("Report is not of the 'csp-report' type")
+        
+        super().__init__(received)
+
+        try:
+            self.blocked_uri = html.escape(csp_report["blocked-uri"], quote=True).split(" ", 1)[0]
+        except KeyError:
+            self.blocked_uri = None
+
+        try:
+            self.document_uri = html.escape(csp_report["document-uri"], quote=True).split(" ", 1)[0]
+        except KeyError:
+            raise RequiredElementMissingError("Missing required element 'document-uri'")
+        
+        try:
+            self.effective_directive = html.escape(csp_report["effective-directive"], quote=True).split(" ", 1)[0]
+        except KeyError:
+            try:
+                self.effective_directive = html.escape(csp_report["violated-directive"], quote=True).split(" ", 1)[0]
+            except KeyError:
+                raise RequiredElementMissingError("Missing required element.  Either 'violated-directive' (deprecated) or 'effective-directive' is required.")
+
+        try:
+            self.sample = html.escape(csp_report["script-sample"], quote=True)
+        except KeyError:
+            self.sample = None
+
+        try:
+            self.referrer = html.escape(csp_report["referrer"], quote=True)
+        except KeyError:
+            self.referrer = None
+
+        self.domain = urlparse(self.document_uri).hostname
+
+        ## Short-ciruit reports for 'about' pages, i.e. about:config, etc.
+        if self.blocked_uri == "about" or self.document_uri == "about":
+            raise AboutException()
+
+        elif not self.blocked_uri:
+            if self.effective_directive == "script-src":
+                self.blocked_uri = "eval"
+
+        elif self.effective_directive == "style-src":
+            self.blocked_uri = "inline"
+
+        try:
+            self.disposition = html.escape(csp_report["disposition"])
+            self.status_code = int(csp_report["status-code"])
+            self.original_policy = html.escape(csp_report["original-policy"])
+        except KeyError as e:
+            raise RequiredElementMissingError(f"Missing required element: {e}")
+
+    def write(self, db: SQLAlchemy) -> None:
+        report = ReportsModel(
+            domain=self.domain,
+            document_uri=self.document_uri,
+            blocked_uri=self.blocked_uri,
+            effective_directive=self.effective_directive,
+            status_code=self.status_code,
+            disposition=self.disposition,
+            sample=self.sample,
+            original_policy=self.original_policy,
+            referrer=self.referrer,
+            reported_at=self.received
+        )
+
+        db.session.add(report)
+        db.session.commit()
+
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
+# See also https://www.w3.org/TR/CSP3/#reporting
+class ReportTo(CSPReport):
+    def __init__(self, request_data: dict, received: datetime = datetime.now(timezone.utc)):
+        super().__init__(received)
+
+        try:
+            if request_data["type"] != "csp-violation":
+                raise RequiredElementMissingError(f"Report type must be 'csp-violation' but got {request_data["type"]}")
+        except KeyError:
+            raise InvalidReportType(f"Report is not a valid csp-violation report")
+        
+        try:
+            self.user_agent = html.escape(request_data["user_agent"], quote=True)
+        except KeyError:
+            self.user_agent = None
+        
+        csp_report = {}
+
+        try:
+            csp_report: dict = request_data["body"]
+            self.document_uri = html.escape(csp_report["documentURL"], quote=True).split(" ", 1)[0]
+            self.domain = urlparse(self.document_uri).hostname
+            self.effective_directive = html.escape(csp_report["effectiveDirective"], quote=True).split(" ", 1)[0]
+            self.disposition = html.escape(csp_report["disposition"], quote=True)
+            self.status_code = int(csp_report["statusCode"])
+            self.original_policy = html.escape(csp_report["originalPolicy"], quote=True)
+            self.sample = html.escape(csp_report["sample"],quote=True)
+        except KeyError as e:
+            raise RequiredElementMissingError("Missing required element '{e}'")
+
+        try:
+            self.blocked_uri = html.escape(csp_report["blockedURL"], quote=True).split(" ", 1)[0]
+        except KeyError:
+            self.blocked_uri = None
+
+        ## Short-ciruit reports for 'about' pages, i.e. about:config, etc.
+        if self.blocked_uri == "about" or self.document_uri == "about":
+            raise AboutException()
+        
+        try:
+            self.column_number = int(csp_report["columnNumber"])
+        except KeyError:
+            self.column_number = None
+
+        try:
+            self.line_number = int(csp_report["lineNumber"])
+        except KeyError:
+            self.line_number = None
+
+        try:
+            self.referrer = html.escape(csp_report["referrer"])
+        except KeyError:
+            self.referrer = None
+
+    def write(self, db: SQLAlchemy) -> None:
+        report = ReportsModel(
+            domain=self.domain,
+            document_uri=self.document_uri,
+            blocked_uri=self.blocked_uri,
+            effective_directive=self.effective_directive,
+            status_code=self.status_code,
+            disposition=self.disposition,
+            original_policy=self.original_policy,
+            line_number=self.line_number,
+            column_number=self.column_number,
+            sample=self.sample,
+            referrer=self.referrer,
+            user_agent=self.user_agent,
+            reported_at=self.received
+        )
+
+        db.session.add(report)
+        db.session.commit()
+
+def get_report(report: dict) -> CSPReport:
+    try:
+        return ReportTo(report)
+    except InvalidReportType:
+        try:
+            return ReportURI(report)
+        except InvalidReportType:
+            raise InvalidReportType("Submitted report could not be serialized: unknown or invalid report type")
+
+csp_content_type = [
+    "application/csp-report", 
+    "application/reports+json"
+]

--- a/src/csp_reports.py
+++ b/src/csp_reports.py
@@ -112,7 +112,7 @@ class ReportTo(CSPReport):
             if request_data["type"] != "csp-violation":
                 raise InvalidReportType(f"Report type must be 'csp-violation' but got {request_data["type"]}")
         except KeyError:
-            raise RequiredElementMissingError(f"Report is not a valid csp-violation report")
+            raise InvalidReportType(f"Report is not a valid csp-violation report: missing 'type': 'csp-violation'")
         
         try:
             self.user_agent = html.escape(request_data["user_agent"], quote=True)

--- a/src/csp_reports.py
+++ b/src/csp_reports.py
@@ -5,6 +5,7 @@ from csp_datamodel import ReportsModel
 
 from datetime import datetime, timezone
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm.session import Session
 from urllib.parse import urlparse
 
 
@@ -84,7 +85,7 @@ class ReportURI(CSPReport):
         except KeyError as e:
             raise RequiredElementMissingError(f"Missing required element: {e}")
 
-    def write(self, db: SQLAlchemy) -> None:
+    def write(self, db_session: Session) -> None:
         report = ReportsModel(
             domain=self.domain,
             document_uri=self.document_uri,
@@ -98,8 +99,8 @@ class ReportURI(CSPReport):
             reported_at=self.received
         )
 
-        db.session.add(report)
-        db.session.commit()
+        db_session.add(report)
+        db_session.commit()
 
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to
 # See also https://www.w3.org/TR/CSP3/#reporting
@@ -156,7 +157,7 @@ class ReportTo(CSPReport):
         except KeyError:
             self.referrer = None
 
-    def write(self, db: SQLAlchemy) -> None:
+    def write(self, db_session: Session) -> None:
         report = ReportsModel(
             domain=self.domain,
             document_uri=self.document_uri,
@@ -173,8 +174,8 @@ class ReportTo(CSPReport):
             reported_at=self.received
         )
 
-        db.session.add(report)
-        db.session.commit()
+        db_session.add(report)
+        db_session.commit()
 
 def get_report(report: dict) -> CSPReport:
     try:

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1,12 +1,12 @@
+html {
+    font-family: sans-serif;
+}
+
 .head {
     width: 100%;
     margin: 0px 0px 0px 10px;
     padding: 10px;
     border-bottom: 2px solid #000;
-}
-
-.head h1 {
-    font-family: sans-serif;
 }
 
 .mainbody {
@@ -27,15 +27,73 @@ tr.row-1 {
     background-color: #b9c4db;
 }
 
-.pager {
+td {
+    padding: .25em;
+}
+
+.navbar {
     text-align: right;
+    width: 100%;
 }
 
-.pager ul {
-    list-style: none
+.navbar ul {
+    list-style: none;
 }
 
-.pager li {
+.navbar li {
     display: inline-block;
-    margin:0px 1em;
+    margin:0;
+    padding:0;
+}
+
+.navbar li.list-separator:before {
+    content: "|";
+    padding: 0 1em;
+}
+
+#crumbs {
+    font-size: .8em;
+    font-family: sans-serif
+}
+
+.report {
+    margin:0;
+    padding:0;
+    width: 100%;
+}
+
+.report .row {
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    font-size: 0em;
+    border-bottom: 1px solid #777;
+}
+
+.header, .data {
+    display: inline-block;
+    margin: 0;
+    padding: 0 0 .5em 0;
+}
+
+.report .header {
+    font-weight: bold;
+    min-width: 150px;
+    font-size: 1rem;
+    margin: 0;
+    padding: .5em 0 .25em 0;
+    width: 20%;
+}
+
+.report .data {
+    min-width: 250px;
+    font-size: 1rem;
+    width: 80%;
+}
+
+.report .data pre {
+    margin: 0px;
+    padding: 0px;
+    font-family: monospace;
+    white-space: nowrap;
 }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -9,10 +9,14 @@
     font-family: sans-serif;
 }
 
-table.reports {
-    border: 1px solid #777;
+.mainbody {
     margin: 1em auto;
     width: 80%;
+}
+
+table.reports {
+    border: 1px solid #777;
+    width: 100%;
 }
 
 tr.row-0 {
@@ -21,4 +25,17 @@ tr.row-0 {
 
 tr.row-1 {
     background-color: #b9c4db;
+}
+
+.pager {
+    text-align: right;
+}
+
+.pager ul {
+    list-style: none
+}
+
+.pager li {
+    display: inline-block;
+    margin:0px 1em;
 }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1,0 +1,24 @@
+.head {
+    width: 100%;
+    margin: 0px 0px 0px 10px;
+    padding: 10px;
+    border-bottom: 2px solid #000;
+}
+
+.head h1 {
+    font-family: sans-serif;
+}
+
+table.reports {
+    border: 1px solid #777;
+    margin: 1em auto;
+    width: 80%;
+}
+
+tr.row-0 {
+    background-color: #9f9f9f;
+}
+
+tr.row-1 {
+    background-color: #b9c4db;
+}

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1,11 +1,12 @@
-html {
+html, body {
     font-family: sans-serif;
+    margin: 0;
+    padding: 0;
 }
 
 .head {
-    width: 100%;
-    margin: 0px 0px 0px 10px;
-    padding: 10px;
+    margin: 0;
+    padding: 1em;
     border-bottom: 2px solid #000;
 }
 
@@ -29,6 +30,16 @@ tr.row-1 {
 
 td {
     padding: .25em;
+}
+
+td a {
+    color: #000075;
+    text-decoration: none;
+}
+
+td a:hover {
+    color: #5555a0;
+    text-decoration: underline;
 }
 
 .navbar {

--- a/src/templates/reports.jinja
+++ b/src/templates/reports.jinja
@@ -12,14 +12,14 @@
         </header>
     </div>
     <div class="mainbody">
-        <div class="pager"><ul><li><a {% if reports.has_prev -%} href="/reports?p={{ reports.prev_num }}"{% endif %}>previous</a></li><li><a {% if reports.has_next -%} href="/reports?p={{reports.next_num }}"{% endif %}>next</a></li></ul></div>
+        <div class="navbar"><ul><li><a {% if reports.has_prev -%} href="/reports?p={{ reports.prev_num }}"{% endif %}>previous</a></li><li class="list-separator"><a {% if reports.has_next -%} href="/reports?p={{reports.next_num }}"{% endif %}>next</a></li></ul></div>
         <table class="reports">
         <tr>
             <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Effective Directive</th><th>Disposition</th><th>Reported Time</th>
         </tr>
         {% for report in reports.items %}
         <tr class="row-{{ loop.index % 2 }}">
-            <td>{{ report.domain }}</td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.effective_directive }}</td><td>{{ report.disposition }}</td><td>{{ report.reported_at }}</td>
+            <td><a href="/reports/{{ report.id }}">{{ report.domain }}</a></td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.effective_directive }}</td><td>{{ report.disposition }}</td><td>{{ report.reported_at }}</td>
         </tr>
         {% endfor %}
         </table>

--- a/src/templates/reports.jinja
+++ b/src/templates/reports.jinja
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf8" />
+        <title>csp reports</title>
+        <link rel="stylesheet" type="text/css" href="/static/style.css" />
+    </head>
+    <body>
+    <div class="head">
+        <header>
+            <h1>CSP Reports</h1>
+        </header>
+    </div>
+    <div class="mainbody">
+        <table class="reports">
+        <tr>
+            <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Violated Directive</th><th>Reported time</th>
+        </tr>
+        {% for report in reports %}
+        <tr class="row-{{ loop.index % 2 }}">
+            <td>{{ report.domain }}</td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.violated_directive }}</td><td>{{ report.reported_at }}</td>
+        </tr>
+        {% endfor %}
+        </table>
+    </div>
+    </body>
+</html>

--- a/src/templates/reports.jinja
+++ b/src/templates/reports.jinja
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8" />
         <title>csp reports</title>
-        <link rel="stylesheet" type="text/css" href="/static/style.css" />
+        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css')}}" />
     </head>
     <body>
     <div class="head">
@@ -12,14 +12,14 @@
         </header>
     </div>
     <div class="mainbody">
-        <div class="navbar"><ul><li><a {% if reports.has_prev -%} href="/reports?p={{ reports.prev_num }}"{% endif %}>previous</a></li><li class="list-separator"><a {% if reports.has_next -%} href="/reports?p={{reports.next_num }}"{% endif %}>next</a></li></ul></div>
+        <div class="navbar"><ul><li><a {% if reports.has_prev -%} href="{{ url_for('display_csp_reports', p=reports.prev_num) }}"{% endif %}>previous</a></li><li class="list-separator"><a {% if reports.has_next -%} href="{{ url_for('display_csp_reports',p=reports.next_num) }}"{% endif %}>next</a></li></ul></div>
         <table class="reports">
         <tr>
             <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Effective Directive</th><th>Disposition</th><th>Reported Time</th>
         </tr>
         {% for report in reports.items %}
         <tr class="row-{{ loop.index % 2 }}">
-            <td><a href="/reports/{{ report.id }}">{{ report.domain }}</a></td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.effective_directive }}</td><td>{{ report.disposition }}</td><td>{{ report.reported_at }}</td>
+            <td><a href="{{ url_for('display_single_report', id=report.id) }}">{{ report.domain }}</a></td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.effective_directive }}</td><td>{{ report.disposition }}</td><td>{{ report.reported_at }}</td>
         </tr>
         {% endfor %}
         </table>

--- a/src/templates/reports.jinja
+++ b/src/templates/reports.jinja
@@ -12,11 +12,12 @@
         </header>
     </div>
     <div class="mainbody">
+        <div class="pager"><ul><li><a {% if reports.has_prev -%} href="/reports?p={{ reports.prev_num }}"{% endif %}>previous</a></li><li><a {% if reports.has_next -%} href="/reports?p={{reports.next_num }}"{% endif %}>next</a></li></ul></div>
         <table class="reports">
         <tr>
             <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Violated Directive</th><th>Reported time</th>
         </tr>
-        {% for report in reports %}
+        {% for report in reports.items %}
         <tr class="row-{{ loop.index % 2 }}">
             <td>{{ report.domain }}</td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.violated_directive }}</td><td>{{ report.reported_at }}</td>
         </tr>

--- a/src/templates/reports.jinja
+++ b/src/templates/reports.jinja
@@ -15,11 +15,11 @@
         <div class="pager"><ul><li><a {% if reports.has_prev -%} href="/reports?p={{ reports.prev_num }}"{% endif %}>previous</a></li><li><a {% if reports.has_next -%} href="/reports?p={{reports.next_num }}"{% endif %}>next</a></li></ul></div>
         <table class="reports">
         <tr>
-            <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Violated Directive</th><th>Reported time</th>
+            <th>Domain</th><th>Document URI</th><th>Blocked URI</th><th>Effective Directive</th><th>Disposition</th><th>Reported Time</th>
         </tr>
         {% for report in reports.items %}
         <tr class="row-{{ loop.index % 2 }}">
-            <td>{{ report.domain }}</td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.violated_directive }}</td><td>{{ report.reported_at }}</td>
+            <td>{{ report.domain }}</td><td>{{ report.document_uri }}</td><td>{{ report.blocked_uri }}</td><td>{{ report.effective_directive }}</td><td>{{ report.disposition }}</td><td>{{ report.reported_at }}</td>
         </tr>
         {% endfor %}
         </table>

--- a/src/templates/reports_detail.jinja
+++ b/src/templates/reports_detail.jinja
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf8" />
+        <title>csp reports :: Detail</title>
+        <link rel="stylesheet" type="text/css" href="/static/style.css" />
+    </head>
+    <body>
+    <div class="head">
+        <header>
+            <h1>Report Detail</h1>
+        </header>
+    </div>
+    <div class="mainbody">
+        <div class="navbar"><span id="crumbs"><a href="/reports">All Reports</a></span></div>
+        <div class="report">
+            <div class="row">
+                <div class="header">
+                    Report Domain
+                </div><div class="data">
+                    {{ report.domain }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Document URI
+                </div><div class="data">
+                    {{ report.document_uri }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Blocked URI
+                </div>
+                <div class="data">
+                    {{ report.blocked_uri }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Effective Directive
+                </div>
+                <div class="data">
+                    {{ report.effective_directive }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Request Status
+                </div>
+                <div class="data">
+                    {{ report.status_code }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Disposition
+                </div>
+                <div class="data">
+                    {{ report.disposition }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Original Policy
+                </div>
+                <div class="data">
+                    {{ report.original_policy }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Line Number
+                </div>
+                <div class="data">
+                    {{ report.line_number }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Column Number
+                </div>
+                <div class="data">
+                    {{ report.column_number }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Sample
+                </div>
+                <div class="data">
+                    <pre>
+                    {{ report.sample }}
+                    </pre>
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Referrer
+                </div>
+                <div class="data">
+                {{ report.referrer }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    User Agent
+                </div>
+                <div class="data">
+                    {{ report.user_agent }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="header">
+                    Report Time
+                </div>
+                <div class="data">
+                    {{ report.reported_at }}
+                </div>
+            </div>
+        </div>
+    </div>
+    </body>
+</html>

--- a/src/templates/reports_detail.jinja
+++ b/src/templates/reports_detail.jinja
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf8" />
         <title>csp reports :: Detail</title>
-        <link rel="stylesheet" type="text/css" href="/static/style.css" />
+        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css') }}" />
     </head>
     <body>
     <div class="head">
@@ -12,7 +12,7 @@
         </header>
     </div>
     <div class="mainbody">
-        <div class="navbar"><span id="crumbs"><a href="/reports">All Reports</a></span></div>
+        <div class="navbar"><span id="crumbs"><a href="{{ url_for('display_csp_reports') }}">All Reports</a></span></div>
         <div class="report">
             <div class="row">
                 <div class="header">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+import csp_datamodel
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+class FixedData(object):
+    @staticmethod
+    def none() -> None:
+        return None
+    
+    @staticmethod
+    def empty() -> str:
+        return ""
+    
+    @staticmethod
+    def content_type(type) -> str:
+        content_types = {
+            "invalid": "text/html",
+            "legacy": "application/csp-report",
+            "preferred": "application/reports+json"
+        }
+
+        try:
+            return content_types[type]
+        except KeyError:
+            return content_types["legacy"]
+        
+    @staticmethod
+    def report_type(type) -> str:    
+        report_types = {
+            "legacy": "csp-report",
+            "preferred": "csp-violation",
+            "invalid": "invalid-report",
+            "missing": ""
+        }
+
+        try:
+            return report_types[type]
+        except KeyError:
+            return ""
+        
+    @staticmethod
+    def request_uri(type) -> str:
+        uris = {
+            "submit": "/csp-report",
+            "list": "/reports",
+            "detail": "/reports/1",
+            "invalid": "/invalid",
+        }
+
+        try:
+            return uris[type]
+        except KeyError:
+            return ""
+        
+    @staticmethod
+    def user_agent() -> str:
+        return "Mozilla/5.0 - pytest"
+    
+    @staticmethod
+    def document_url() -> str:
+        return "https://pytest.test-domain.com/test"
+
+    @staticmethod
+    def blocked_url() -> str:
+        return "https://www.evil.com/payload/evil.js"
+
+    @staticmethod
+    def effective_directive() -> str:
+        return "inline-src"
+    
+    @staticmethod
+    def original_policy() -> str:
+        return "default-src 'self';"
+
+    @staticmethod
+    def referrer() -> str:
+        return "https://www.duckduckgo.com"
+
+    @staticmethod
+    def source_file() -> str:
+        return "https://my-domain.com/about"
+
+    @staticmethod
+    def disposition() -> str:
+        return "enforce"
+
+    @staticmethod
+    def column_number() -> str:
+        return "39"
+
+    @staticmethod
+    def line_number() -> str:
+        return "17"
+
+    @staticmethod
+    def code_sample() -> str:
+        return "<javascript>alert(1);</javascript>"
+
+    @staticmethod
+    def status_code() -> str:
+        return "200"
+
+@pytest.fixture(scope="function")
+def get_db():
+    engine = create_engine("sqlite:///:memory:")
+    csp_datamodel.ReportsModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine,expire_on_commit=False)
+    with Session() as db:
+        yield db

--- a/tests/test_csp_reports.py
+++ b/tests/test_csp_reports.py
@@ -1,0 +1,251 @@
+import csp_reports
+import csp_datamodel
+import json
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+@pytest.fixture
+def empty():
+    return ""
+
+@pytest.fixture
+def none():
+    return None
+
+@pytest.fixture
+def legacy_report_type():
+    return "csp-report"
+
+@pytest.fixture
+def report_type():
+    return "csp-violation"
+
+@pytest.fixture
+def user_agent():
+    return "Mozilla/5.0 - pytest"
+
+@pytest.fixture
+def document_url():
+    return "https://pytest.test-domain.com/test"
+
+@pytest.fixture
+def blocked_url():
+    return "https://www.evil.com/payload/evil.js"
+
+@pytest.fixture
+def effective_directive():
+    return "inline-src"
+
+@pytest.fixture
+def original_policy():
+    return "default-src 'self';"
+
+@pytest.fixture
+def referrer():
+    return "https://www.duckduckgo.com"
+
+@pytest.fixture
+def source_file():
+    return "https://my-domain.com/about"
+
+@pytest.fixture
+def disposition():
+    return "enforce"
+
+@pytest.fixture
+def column_number():
+    return "39"
+
+@pytest.fixture
+def line_number():
+    return "17"
+
+@pytest.fixture
+def sample():
+    return "<javascript>alert(1);</javascript>"
+
+@pytest.fixture
+def status_code():
+    return "200"
+
+@pytest.fixture()
+def get_db():
+    engine = create_engine("sqlite:///:memory:")
+    csp_datamodel.ReportsModel.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine,expire_on_commit=False)
+    with Session() as db:
+        yield db
+
+def generate_report_to(*args) -> dict:
+    report_to_keys = [
+        "type",
+        "user_agent",
+        "url",
+    ]
+    report_to_body_keys = [
+        "blockedURL",
+        "documentURL",
+        "effectiveDirective",
+        "originalPolicy",
+        "referrer",
+        "disposition",
+        "sourceFile",
+        "columnNumber",
+        "lineNumber",
+        "sample",
+        "statusCode"
+    ]
+
+    report_to = {}
+    argc=0
+    for key in report_to_keys:
+        try:
+            if args[argc] is not None:
+                report_to[key] = args[argc]
+        except KeyError:
+            pass
+        finally:
+            argc+=1
+
+    report_body = {}
+    for key in report_to_body_keys:
+        try:
+            if args[argc] is not None:
+                report_body[key] = args[argc]
+        except KeyError:
+            pass
+        finally:
+            argc+=1
+    report_to["body"] = report_body
+
+    return report_to
+
+def generate_report_uri(*args) -> dict:
+    report_uri_keys = [
+        "blocked-uri",
+        "document-uri",
+        "disposition",
+        "effective-directive",
+        "violated-directive",
+        "original-policy",
+        "referrer",
+        "script-sample",
+        "status-code",
+    ]
+    if not args[0]:
+        report_uri = {}
+    else:
+        report_uri = {args[0]:{}}
+    argc = 1
+
+    for key in report_uri_keys:
+        try:
+            if args[argc] is not None:
+                if not args[0]:
+                    report_uri[key] = args[argc]
+                else:
+                    report_uri[args[0]][key] = args[argc]
+        except KeyError:
+            pass
+        finally:
+            argc+=1
+
+    return report_uri
+
+@pytest.fixture
+def report_to(report_type,user_agent, document_url, blocked_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
+    return generate_report_to(report_type,user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code)
+
+@pytest.fixture
+def report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, original_policy, referrer, sample, status_code):
+    return generate_report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code)
+
+def test_report_factory_reportto(report_to):
+    print(f"report to: {report_to}")
+    assert isinstance(csp_reports.get_report(report_to), csp_reports.ReportTo)
+
+def test_report_factory_reporturi(report_uri):
+    print(f"report uri: {report_uri}")
+    assert isinstance(csp_reports.get_report(report_uri), csp_reports.ReportURI)
+
+def test_write_database_legacy(report_uri,get_db):
+    report = csp_reports.get_report(report_uri)
+    db = get_db
+    report.write(db)
+    assert db.query(csp_datamodel.ReportsModel).count() == 1
+
+def test_write_database(report_to,get_db):
+    report = csp_reports.get_report(report_to)
+    db = get_db
+    report.write(db)
+    assert db.query(csp_datamodel.ReportsModel).count() == 1
+
+@pytest.mark.parametrize(
+    [
+        "legacy_report_type",
+        "blocked_url",
+        "document_url",
+        "disposition",
+        "effective_directive",
+        "violated_directive",
+        "original_policy",
+        "referrer",
+        "script",
+        "status_code"
+    ],
+    [
+        pytest.param(none, blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-type"),
+        pytest.param(legacy_report_type, none, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-blocked-url"),
+        pytest.param(legacy_report_type, blocked_url, none, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-document-url"),
+        pytest.param(legacy_report_type, blocked_url, document_url, none, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-disposition"),
+        pytest.param(legacy_report_type, blocked_url, document_url, disposition, none, none, original_policy, referrer, sample, status_code, id="missing-effective-directive"),
+        pytest.param(legacy_report_type, blocked_url, document_url, disposition, effective_directive, effective_directive, none, referrer, sample, status_code, id="missing-policy"),
+        pytest.param(legacy_report_type, blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, none, id="missing-code"),
+    ]
+)
+def test_validate_required_elements_legacy(legacy_report_type, blocked_url, document_url, disposition, effective_directive, violated_directive, original_policy, referrer, script, status_code):
+    with pytest.raises(csp_reports.RequiredElementMissingError):
+        report = csp_reports.get_report(generate_report_uri(legacy_report_type, blocked_url, document_url, disposition, effective_directive, violated_directive, original_policy, referrer, script, status_code))
+
+@pytest.mark.parametrize(
+    [
+        "report_type",
+        "user_agent",
+        "url", 
+        "blocked_url",
+        "document_url",
+        "effective_directive",
+        "original_policy",
+        "referrer",
+        "disposition",
+        "source_file",
+        "column_number",
+        "line_number",
+        "sample",
+        "status_code"
+    ],
+    [
+        pytest.param(none, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-type"),
+        pytest.param(report_type, user_agent, document_url, none, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-blocked-url"),
+        pytest.param(report_type, user_agent, document_url, blocked_url, none, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-document-url"),
+        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, none, source_file, column_number, line_number, sample, status_code, id="missing-disposition"),
+        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, none, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-effective-directive"),
+        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, none, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-policy"),
+        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, none, id="missing-code"),
+    ]
+)
+def test_validate_required_elements(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
+    with pytest.raises(csp_reports.RequiredElementMissingError):
+        report = csp_reports.get_report(generate_report_to(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code))
+
+def test_invalid_report_type_legacy():
+    with pytest.raises(csp_reports.InvalidReportType):
+        invalid_report_type = "invalid-type"
+        report = csp_reports.get_report(generate_report_uri(invalid_report_type,blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code))
+
+def test_invalid_report_type():
+    with pytest.raises(csp_reports.InvalidReportType):
+        invalid_report_type = "invalid-type"
+        report = csp_reports.get_report(generate_report_to(invalid_report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code))

--- a/tests/test_csp_reports.py
+++ b/tests/test_csp_reports.py
@@ -1,82 +1,8 @@
 import csp_reports
 import csp_datamodel
-import json
 import pytest
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-@pytest.fixture
-def empty():
-    return ""
-
-@pytest.fixture
-def none():
-    return None
-
-@pytest.fixture(scope="module")
-def legacy_report_type():
-    return "csp-report"
-
-@pytest.fixture(scope="module")
-def report_type():
-    return "csp-violation"
-
-@pytest.fixture(scope="module")
-def user_agent():
-    return "Mozilla/5.0 - pytest"
-
-@pytest.fixture(scope="module")
-def document_url():
-    return "https://pytest.test-domain.com/test"
-
-@pytest.fixture(scope="module")
-def blocked_url():
-    return "https://www.evil.com/payload/evil.js"
-
-@pytest.fixture(scope="module")
-def effective_directive():
-    return "inline-src"
-
-@pytest.fixture(scope="module")
-def original_policy():
-    return "default-src 'self';"
-
-@pytest.fixture(scope="module")
-def referrer():
-    return "https://www.duckduckgo.com"
-
-@pytest.fixture(scope="module")
-def source_file():
-    return "https://my-domain.com/about"
-
-@pytest.fixture(scope="module")
-def disposition():
-    return "enforce"
-
-@pytest.fixture(scope="module")
-def column_number():
-    return "39"
-
-@pytest.fixture(scope="module")
-def line_number():
-    return "17"
-
-@pytest.fixture(scope="module")
-def sample():
-    return "<javascript>alert(1);</javascript>"
-
-@pytest.fixture(scope="module")
-def status_code():
-    return "200"
-
-@pytest.fixture(scope="function")
-def get_db():
-    engine = create_engine("sqlite:///:memory:")
-    csp_datamodel.ReportsModel.metadata.create_all(engine)
-    Session = sessionmaker(bind=engine,expire_on_commit=False)
-    with Session() as db:
-        yield db
+from conftest import FixedData
 
 def generate_report_to(*args) -> dict:
     report_to_keys = [
@@ -155,12 +81,38 @@ def generate_report_uri(*args) -> dict:
     return report_uri
 
 @pytest.fixture(scope="function")
-def report_to(report_type,user_agent, document_url, blocked_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
-    return generate_report_to(report_type,user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code)
+def report_to():
+    return generate_report_to(
+        FixedData.report_type("preferred"),
+        FixedData.user_agent(),
+        FixedData.document_url(),
+        FixedData.blocked_url(),
+        FixedData.document_url(), 
+        FixedData.effective_directive(),
+        FixedData.original_policy(),
+        FixedData.referrer(),
+        FixedData.disposition(),
+        FixedData.source_file(),
+        FixedData.column_number(),
+        FixedData.line_number(),
+        FixedData.code_sample(),
+        FixedData.status_code()
+    )
 
 @pytest.fixture(scope="function")
-def report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, original_policy, referrer, sample, status_code):
-    return generate_report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code)
+def report_uri():
+    return generate_report_uri(
+        FixedData.report_type("legacy"),
+        FixedData.blocked_url(),
+        FixedData.document_url(),
+        FixedData.disposition(),
+        FixedData.effective_directive(),
+        FixedData.effective_directive(),
+        FixedData.original_policy(),
+        FixedData.referrer(),
+        FixedData.code_sample(),
+        FixedData.status_code()
+    )
 
 def test_report_factory_reportto(report_to):
     print(f"report to: {report_to}")
@@ -196,13 +148,12 @@ def test_write_database(report_to,get_db):
         "status_code"
     ],
     [
-        pytest.param(none, blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-type"),
-        pytest.param(legacy_report_type, none, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-blocked-url"),
-        pytest.param(legacy_report_type, blocked_url, none, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-document-url"),
-        pytest.param(legacy_report_type, blocked_url, document_url, none, effective_directive, effective_directive, original_policy, referrer, sample, status_code, id="missing-disposition"),
-        pytest.param(legacy_report_type, blocked_url, document_url, disposition, none, none, original_policy, referrer, sample, status_code, id="missing-effective-directive"),
-        pytest.param(legacy_report_type, blocked_url, document_url, disposition, effective_directive, effective_directive, none, referrer, sample, status_code, id="missing-policy"),
-        pytest.param(legacy_report_type, blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, none, id="missing-code"),
+        pytest.param(FixedData.none(), FixedData.blocked_url(), FixedData.document_url(), FixedData.disposition(), FixedData.effective_directive(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code(), id="missing-type"),
+        pytest.param(FixedData.report_type("legacy"), FixedData.blocked_url(), FixedData.none(), FixedData.disposition(), FixedData.effective_directive(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code(), id="missing-document-url"),
+        pytest.param(FixedData.report_type("legacy"), FixedData.blocked_url(), FixedData.document_url(), FixedData.none(), FixedData.effective_directive(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code(), id="missing-disposition"),
+        pytest.param(FixedData.report_type("legacy"), FixedData.blocked_url(), FixedData.document_url(), FixedData.disposition(), FixedData.none(), FixedData.none(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code(), id="missing-effective-directive"),
+        pytest.param(FixedData.report_type("legacy"), FixedData.blocked_url(), FixedData.document_url(), FixedData.disposition(), FixedData.effective_directive(), FixedData.effective_directive(), FixedData.none(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code(), id="missing-policy"),
+        pytest.param(FixedData.report_type("legacy"), FixedData.blocked_url(), FixedData.document_url(), FixedData.disposition(), FixedData.effective_directive(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.none(), id="missing-code"),
     ]
 )
 def test_validate_required_elements_legacy(legacy_report_type, blocked_url, document_url, disposition, effective_directive, violated_directive, original_policy, referrer, script, status_code):
@@ -223,29 +174,66 @@ def test_validate_required_elements_legacy(legacy_report_type, blocked_url, docu
         "source_file",
         "column_number",
         "line_number",
+        "script",
+        "status_code"
+    ],
+    [
+        pytest.param(FixedData.none(), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.document_url(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code(), id="missing-type"),
+        pytest.param(FixedData.report_type("preferred"), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.none(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code(), id="missing-document-url"),
+        pytest.param(FixedData.report_type("preferred"), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.document_url(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.none(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code(), id="missing-disposition"),
+        pytest.param(FixedData.report_type("preferred"), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.document_url(), FixedData.none(), FixedData.original_policy(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code(), id="missing-effective-directive"),
+        pytest.param(FixedData.report_type("preferred"), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.document_url(), FixedData.effective_directive(), FixedData.none(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code(), id="missing-policy"),
+        pytest.param(FixedData.report_type("preferred"), FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.document_url(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.none(), id="missing-code"),
+    ]
+)
+def test_validate_required_elements(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, script, status_code):
+    with pytest.raises(csp_reports.RequiredElementMissingError):
+        report = csp_reports.get_report(generate_report_to(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, script, status_code))
+
+@pytest.mark.parametrize(
+    [
+        "document_url",
+        "blocked_url",
+        "disposition",
+        "effective_directive",
+        "original_policy",
+        "referrer",
         "sample",
         "status_code"
     ],
     [
-        pytest.param(none, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-type"),
-        pytest.param(report_type, user_agent, document_url, none, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-blocked-url"),
-        pytest.param(report_type, user_agent, document_url, blocked_url, none, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-document-url"),
-        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, none, source_file, column_number, line_number, sample, status_code, id="missing-disposition"),
-        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, none, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-effective-directive"),
-        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, none, referrer, disposition, source_file, column_number, line_number, sample, status_code, id="missing-policy"),
-        pytest.param(report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, none, id="missing-code"),
+        (FixedData.document_url(), FixedData.blocked_url(), FixedData.disposition(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.code_sample(), FixedData.status_code())
     ]
 )
-def test_validate_required_elements(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
-    with pytest.raises(csp_reports.RequiredElementMissingError):
-        report = csp_reports.get_report(generate_report_to(report_type, user_agent, url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code))
-
-def test_invalid_report_type_legacy():
+def test_invalid_report_type_legacy(document_url, blocked_url, disposition, effective_directive, original_policy, referrer, sample, status_code):
     with pytest.raises(csp_reports.InvalidReportType):
         invalid_report_type = "invalid-type"
         report = csp_reports.get_report(generate_report_uri(invalid_report_type,blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code))
 
-def test_invalid_report_type():
+@pytest.mark.parametrize(
+        [
+            "user_agent",
+            "document_url",
+            "blocked_url",
+            "effective_directive",
+            "original_policy",
+            "referrer",
+            "disposition",
+            "source_file",
+            "column_number",
+            "line_number",
+            "sample",
+            "status_code"
+        ],
+        [
+            (FixedData.user_agent(), FixedData.document_url(), FixedData.blocked_url(), FixedData.effective_directive(), FixedData.original_policy(), FixedData.referrer(), FixedData.disposition(), FixedData.source_file(), FixedData.column_number(), FixedData.line_number(), FixedData.code_sample(), FixedData.status_code())
+        ]
+)
+def test_invalid_report_type(user_agent, document_url, blocked_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
     with pytest.raises(csp_reports.InvalidReportType):
         invalid_report_type = "invalid-type"
         report = csp_reports.get_report(generate_report_to(invalid_report_type, user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvv", "--no-cov"])

--- a/tests/test_csp_reports.py
+++ b/tests/test_csp_reports.py
@@ -14,63 +14,63 @@ def empty():
 def none():
     return None
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def legacy_report_type():
     return "csp-report"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def report_type():
     return "csp-violation"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def user_agent():
     return "Mozilla/5.0 - pytest"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def document_url():
     return "https://pytest.test-domain.com/test"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def blocked_url():
     return "https://www.evil.com/payload/evil.js"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def effective_directive():
     return "inline-src"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def original_policy():
     return "default-src 'self';"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def referrer():
     return "https://www.duckduckgo.com"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def source_file():
     return "https://my-domain.com/about"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def disposition():
     return "enforce"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def column_number():
     return "39"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def line_number():
     return "17"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def sample():
     return "<javascript>alert(1);</javascript>"
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def status_code():
     return "200"
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def get_db():
     engine = create_engine("sqlite:///:memory:")
     csp_datamodel.ReportsModel.metadata.create_all(engine)
@@ -154,11 +154,11 @@ def generate_report_uri(*args) -> dict:
 
     return report_uri
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def report_to(report_type,user_agent, document_url, blocked_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code):
     return generate_report_to(report_type,user_agent, document_url, blocked_url, document_url, effective_directive, original_policy, referrer, disposition, source_file, column_number, line_number, sample, status_code)
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, original_policy, referrer, sample, status_code):
     return generate_report_uri(legacy_report_type,blocked_url, document_url, disposition, effective_directive, effective_directive, original_policy, referrer, sample, status_code)
 


### PR DESCRIPTION
This is an extensive update that includes a number of significant changes.  Given the significant changes, including db schema changes, I bumped the version all the way up to 1.0.0.  This version is incompatible with previous versions and may require manually updating/converting the database.  Automated "upgrade" is out of scope for this PR, but could be wrestled with later, if desired.

* (feature) New endpoint `/reports` that will display a paginated table of submitted reports
* (feature) New endpoint `/reports/<report_id>` will display all the details of an individual report
* (feature) The collector supports both the legacy `report-uri` report format and the new `report-to` format
* (tests) Tests updated to reflect the refactoring of code into separate modules
* (chore) Pipfile and Pipfile.lock updated with latest library versions and trimmed down what wasn't needed
* (chore) Dockerfile uses multi-stage build to reduce surface area and image size
* (chore) Dockerfile updated to include all the new assets